### PR TITLE
fix: make cookie expire after 30 days

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -108,7 +108,10 @@
 
               // Update cookies with response data (e.g., accessToken and username)
               if (data.session_token) {
-                document.cookie = "session_token=" + data.session_token;
+                let date = new Date();
+                date.setTime(date.getTime() + (30 * 24 * 60 * 60 * 1000));
+                document.cookie = "session_token=" + data.session_token + "; "
+                                  + "expires=" + date.toUTCString() + ";";
                 // localStorage.setItem("session_token", data.session_token);
               }
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -109,7 +109,8 @@
               // Update cookies with response data (e.g., accessToken and username)
               if (data.session_token) {
                 let date = new Date();
-                date.setTime(date.getTime() + (30 * 24 * 60 * 60 * 1000));
+                const days_to_expire = 30
+                date.setTime(date.getTime() + (days_to_expire * 24 * 60 * 60 * 1000));
                 document.cookie = "session_token=" + data.session_token + "; "
                                   + "expires=" + date.toUTCString() + ";";
                 // localStorage.setItem("session_token", data.session_token);

--- a/templates/login.html
+++ b/templates/login.html
@@ -109,8 +109,9 @@
               // Update cookies with response data (e.g., accessToken and username)
               if (data.session_token) {
                 let date = new Date();
+                const day = 24 * 60 * 60 * 1000
                 const days_to_expire = 30
-                date.setTime(date.getTime() + (days_to_expire * 24 * 60 * 60 * 1000));
+                date.setTime(date.getTime() + (days_to_expire * day));
                 document.cookie = "session_token=" + data.session_token + "; "
                                   + "expires=" + date.toUTCString() + ";";
                 // localStorage.setItem("session_token", data.session_token);


### PR DESCRIPTION
This makes it so that cookies expire after 30 days of inactivity rather than when the session is closed.